### PR TITLE
Allow to provide Optional param value in Uri.param

### DIFF
--- a/core/shared/src/main/scala/sttp/model/Uri.scala
+++ b/core/shared/src/main/scala/sttp/model/Uri.scala
@@ -114,6 +114,11 @@ case class Uri private (
   def param(k: String, v: String): Uri = params(k -> v)
 
   /**
+    * Adds the given parameter with optional value to the query if it present.
+    */
+  def param(k: String, v: Option[String]): Uri = v.map(param(k,_)).getOrElse(this)
+
+  /**
     * Adds the given parameters to the query.
     */
   def params(ps: Map[String, String]): Uri = params(ps.toSeq: _*)

--- a/core/shared/src/main/scala/sttp/model/Uri.scala
+++ b/core/shared/src/main/scala/sttp/model/Uri.scala
@@ -114,7 +114,7 @@ case class Uri private (
   def param(k: String, v: String): Uri = params(k -> v)
 
   /**
-    * Adds the given parameter with optional value to the query if it present.
+    * Adds the given parameter with an optional value to the query if it is present.
     */
   def param(k: String, v: Option[String]): Uri = v.map(param(k,_)).getOrElse(this)
 


### PR DESCRIPTION
Hey, thanks for a great library.

It would be great if we could provide optional values to the `Uri.param` like

```
request.
    param("test", Some(testValue))
```