### PR TITLE
Make scheme required in uri interpolation

### DIFF
--- a/core/shared/src/main/scala/sttp/model/UriInterpolator.scala
+++ b/core/shared/src/main/scala/sttp/model/UriInterpolator.scala
@@ -338,7 +338,8 @@ object UriInterpolator {
     case object Scheme extends UriBuilder {
       override def fromTokens(u: Uri, t: Vector[Token]): (Uri, Vector[Token]) = {
         split(t, Set[Token](SchemeEnd)) match {
-          case Left(tt) => (u.scheme("http"), tt)
+          case Left(_) =>
+            throw new IllegalArgumentException("missing scheme")
           case Right((schemeTokens, _, otherTokens)) =>
             val scheme = tokensToString(schemeTokens)
             (u.scheme(scheme), otherTokens)

--- a/core/shared/src/test/scala/sttp/model/UriInterpolatorTests.scala
+++ b/core/shared/src/test/scala/sttp/model/UriInterpolatorTests.scala
@@ -28,8 +28,7 @@ class UriInterpolatorTests extends AnyFunSuite with Matchers {
     ),
     "scheme" -> List(
       (uri"http${if (secure) "s" else ""}://example.com", s"https://example.com"),
-      (uri"${if (secure) "https" else "http"}://example.com", s"https://example.com"),
-      (uri"example.com?a=$v2", s"http://example.com?a=$v2queryEncoded")
+      (uri"${if (secure) "https" else "http"}://example.com", s"https://example.com")
     ),
     "user info" -> List(
       (uri"http://user:pass@example.com", s"http://user:pass@example.com"),
@@ -57,8 +56,7 @@ class UriInterpolatorTests extends AnyFunSuite with Matchers {
       (uri"http://192.168.1.2/x", s"http://192.168.1.2/x"),
       (uri"http://${"192.168.1.2"}/x", s"http://192.168.1.2/x"),
       (uri"http://abc/x", s"http://abc/x"),
-      (uri"http://${"abc"}/x", s"http://abc/x"),
-      (uri"abc", s"http://abc")
+      (uri"http://${"abc"}/x", s"http://abc/x")
     ),
     "ipv6" -> List(
       (uri"http://[::1]/x", s"http://[::1]/x"),
@@ -168,6 +166,7 @@ class UriInterpolatorTests extends AnyFunSuite with Matchers {
   }
 
   val validationTestData = List(
+    ("uri with no scheme", () => uri"example.com", "missing scheme"),
     ("uri with two ports", () => uri"http://example.com:80:80", "port specified multiple times"),
     ("uri with embedded host+port and port", () => uri"http://${"example.com:80"}:80", "port specified multiple times")
   )


### PR DESCRIPTION
Closes #2.

This is a breaking change for those who rely on the uri interpolation to provide `http` as the default scheme.

Work required for softwaremill/sttp#396 seems to be a lot more involved, so I plan to tackle that issue in another PR.