### PR TITLE
fixed cookie expires parsing issue

### DIFF
--- a/core/shared/src/main/scala/sttp/model/Cookie.scala
+++ b/core/shared/src/main/scala/sttp/model/Cookie.scala
@@ -2,6 +2,7 @@ package sttp.model
 
 import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 import sttp.model.internal.{Rfc2616, Validate}
 import sttp.model.internal.Validate._
@@ -271,7 +272,7 @@ object CookieWithMeta {
   //
 
   private val Rfc850Pattern = "E, dd-MMM-yyyy HH:mm:ss zzz"
-  private val Rfc850Format = DateTimeFormatter.ofPattern(Rfc850Pattern)
+  private val Rfc850Format = DateTimeFormatter.ofPattern(Rfc850Pattern, Locale.US)
 
   private def parseDatetime(v: String): Either[Unit, Instant] =
     Try(Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(v))) match {


### PR DESCRIPTION
Hi. Thank you for your great libraries. I've faced with cookie expires parsing issue. If you run ```CookieTest``` with ```-Duser.country=cn -Duser.language=zh``` VM parameters you will see that test for  ```"x=y; Expires=Mon, 27-Jan-2020 16:10:25 GMT"``` has failed. Thats because ```DateTimeFormatter.ofPattern(Rfc850Pattern)``` dateformatter internally will emit Locale dependant week day names. According to [rfc2616](https://tools.ietf.org/html/rfc2616#section-3.3.1) only English week day names allowed. So I think for above dateformatter locale should be setted to US locale (This fixes ```CookieTest``` for ```-Duser.country=cn -Duser.language=zh``` VM parameters )