### PR TITLE
Handling mailformed (in respect to date) weekday names

### DIFF
--- a/core/jvm/src/test/scala/sttp/model/CookieTest.scala
+++ b/core/jvm/src/test/scala/sttp/model/CookieTest.scala
@@ -24,6 +24,13 @@ class CookieTest extends AnyFlatSpec with Matchers {
     ),
     "" -> Right(CookieWithMeta.unsafeApply("", "")),
     "x=y; Max-Age=z" -> Left("Max-Age cookie directive is not a number: z"),
+    "x=y; Expires=Thu, 01-Jan-2114 00:00:10 GMT" -> Right(
+      CookieWithMeta.unsafeApply(
+        "x",
+        "y",
+        Some(ZonedDateTime.of(2114, 1, 1, 0, 0, 10, 0, ZoneId.of("GMT")).toInstant)
+      )
+    ),
     "x=y; Expires=Mon, 27-Jan-2020 16:10:25 GMT" -> Right(
       CookieWithMeta.unsafeApply(
         "x",

--- a/core/shared/src/main/scala/sttp/model/Cookie.scala
+++ b/core/shared/src/main/scala/sttp/model/Cookie.scala
@@ -269,16 +269,25 @@ object CookieWithMeta {
     result
   }
 
-  //
+  private val Rfc850DatetimePattern = "dd-MMM-yyyy HH:mm:ss zzz"
+  private val Rfc850DatetimeFormat = DateTimeFormatter.ofPattern(Rfc850DatetimePattern, Locale.US)
 
-  private val Rfc850Pattern = "E, dd-MMM-yyyy HH:mm:ss zzz"
-  private val Rfc850Format = DateTimeFormatter.ofPattern(Rfc850Pattern, Locale.US)
+  val Rfc850WeekDays = Set("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+  private def parseRfc850DateTime(v: String): Instant = {
+    val expiresParts = v.split(", ")
+    if(expiresParts.length !=2 )
+      throw new Exception("There must be exactly one \", \"")
+    if(!Rfc850WeekDays.contains(expiresParts(0)))
+      throw new Exception("String must start with name of the days of the week")
+    Instant.from(Rfc850DatetimeFormat.parse(expiresParts(1)))
+  }
 
   private def parseDatetime(v: String): Either[Unit, Instant] =
     Try(Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(v))) match {
       case Success(r) => Right(r)
       case Failure(_) =>
-        Try(Instant.from(Rfc850Format.parse(v))) match {
+        Try(parseRfc850DateTime(v)) match {
           case Success(r) => Right(r)
           case Failure(_) => Left(())
         }


### PR DESCRIPTION
I've faced with next _expires value_ ```Thu, 01-Jan-2114 00:00:10 GMT``` It seems to look good but 01-Jan-2114 is Monday not Thursday.  Using DateTimeFormatter's parse method causes exception due wrong weekday name. I'm not sure if [standard](https://tools.ietf.org/html/rfc2616#section-3.3.1) contains explicit requrement to week day name relation to date, but above _expires value_ string is correct in sense of _expires value_ grammar. ```java.net.HttpCookie``` for that string simply doesnt parse _expires value_. There is no any exceptions in ```java.net.HttpCookie.parse```. In turn Google Chrome doesnt drop such cookie or _expires value_ .That looks logically becase weekday name is some kind of redundant information. I think Google Chrome behaviour can be considered as canonical in the case. So I've tried to adapt Rfc850 datetime parsing to that Chrome behaviour in this PR