### PR TITLE
Provide default values for `CookieValueWithMeta`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ core/native/local.sbt
 
 # Scala Native
 lowered.hnir
+
+# Bloop / Metals
+.bloop/
+.metals/
+project/metals.sbt

--- a/core/shared/src/main/scala/sttp/model/Cookie.scala
+++ b/core/shared/src/main/scala/sttp/model/Cookie.scala
@@ -84,27 +84,28 @@ object CookieValueWithMeta {
       Some(s"Value of directive $directiveName name can contain any characters except ; and control characters")
     } else None
   }
+
   def unsafeApply(
       value: String,
-      expires: Option[Instant],
-      maxAge: Option[Long],
-      domain: Option[String],
-      path: Option[String],
-      secure: Boolean,
-      httpOnly: Boolean,
-      otherDirectives: Map[String, Option[String]]
+      expires: Option[Instant] = None,
+      maxAge: Option[Long] = None,
+      domain: Option[String] = None,
+      path: Option[String] = None,
+      secure: Boolean = false,
+      httpOnly: Boolean = false,
+      otherDirectives: Map[String, Option[String]] = Map.empty
   ): CookieValueWithMeta =
     safeApply(value, expires, maxAge, domain, path, secure, httpOnly, otherDirectives).getOrThrow
 
   def safeApply(
       value: String,
-      expires: Option[Instant],
-      maxAge: Option[Long],
-      domain: Option[String],
-      path: Option[String],
-      secure: Boolean,
-      httpOnly: Boolean,
-      otherDirectives: Map[String, Option[String]]
+      expires: Option[Instant] = None,
+      maxAge: Option[Long] = None,
+      domain: Option[String] = None,
+      path: Option[String] = None,
+      secure: Boolean = false,
+      httpOnly: Boolean = false,
+      otherDirectives: Map[String, Option[String]] = Map.empty
   ): Either[String, CookieValueWithMeta] = {
     Validate.all(
       Cookie.validateValue(value),


### PR DESCRIPTION
Add default values for the `safeApply` and `unsafeApply` methods on
`CookieValueWithMeta` to ease usage.

Also `.gitignore` contains now entries to ignore files generated by
Bloop and Metals.