### PR TITLE
Add convenience .accept method to Header companion

### DIFF
--- a/core/src/main/scala/sttp/model/Header.scala
+++ b/core/src/main/scala/sttp/model/Header.scala
@@ -65,6 +65,7 @@ object Header {
 
   //
 
+  def accept(mediaType: MediaType, additionalMediaTypes: MediaType*): Header = accept(s"${(mediaType::additionalMediaTypes.toList).map(_.noCharset).mkString(", ")}")
   def accept(mediaRanges: String): Header = Header(HeaderNames.Accept, mediaRanges)
   def acceptCharset(charsetRanges: String): Header = Header(HeaderNames.AcceptCharset, charsetRanges)
   def acceptEncoding(encodingRanges: String): Header = Header(HeaderNames.AcceptEncoding, encodingRanges)


### PR DESCRIPTION
When adding the "Accept" header to a request it is convenient
to be able to use the defined MediaTypes rather than having
to construct the string yourself