### PR TITLE
Fixed form-data params encoding

### DIFF
--- a/core/src/main/scala/sttp/model/Part.scala
+++ b/core/src/main/scala/sttp/model/Part.scala
@@ -41,10 +41,12 @@ case class Part[+T](
 
   def contentDispositionHeaderValue: String = {
     def encode(s: String): String = new String(s.getBytes("utf-8"), "iso-8859-1")
-    "form-data; " + dispositionParams.map { case (k, v) => s"$k=${encode(v)}" }.mkString("; ")
+    "form-data; " + dispositionParams.map { case (k, v) => s"""$k="${encode(v)}"""" }.mkString("; ")
   }
 
-  def dispositionParams: Map[String, String] = otherDispositionParams + (NameDispositionParam -> name)
+  // some servers require 'name' disposition parameter to be first
+  // see: https://stackoverflow.com/questions/20261088/certain-order-of-fields-in-content-disposition-with-jersey-client
+  def dispositionParams: Map[String, String] = Map(NameDispositionParam -> name) ++ otherDispositionParams
 }
 
 object Part {

--- a/core/src/main/scala/sttp/model/Part.scala
+++ b/core/src/main/scala/sttp/model/Part.scala
@@ -41,12 +41,15 @@ case class Part[+T](
 
   def contentDispositionHeaderValue: String = {
     def encode(s: String): String = new String(s.getBytes("utf-8"), "iso-8859-1")
-    "form-data; " + dispositionParams.map { case (k, v) => s"""$k="${encode(v)}"""" }.mkString("; ")
+    "form-data; " + orderedDispositionParams.map { case (k, v) => s"""$k="${encode(v)}"""" }.mkString("; ")
   }
+
+  def dispositionParams: Map[String, String] = orderedDispositionParams.toMap
 
   // some servers require 'name' disposition parameter to be first
   // see: https://stackoverflow.com/questions/20261088/certain-order-of-fields-in-content-disposition-with-jersey-client
-  def dispositionParams: Map[String, String] = Map(NameDispositionParam -> name) ++ otherDispositionParams
+  def orderedDispositionParams: List[(String, String)] = (NameDispositionParam -> name) :: otherDispositionParams.toList
+
 }
 
 object Part {


### PR DESCRIPTION
Found couple of issues while fixing https://github.com/softwaremill/sttp/issues/773:
1) form-data disposition parameters' values should be enquoted
2) some HTTP servers expect `name` to be the first parameter