### PR TITLE
Support encoding of 3+ UTF-8 byte characters

### DIFF
--- a/core/src/main/scala/sttp/model/internal/Rfc3986.scala
+++ b/core/src/main/scala/sttp/model/internal/Rfc3986.scala
@@ -26,15 +26,14 @@ object Rfc3986 {
   ): String = {
     val sb = new StringBuilder()
     // based on https://gist.github.com/teigen/5865923
-    for (c <- s) {
+    for (b <- s.getBytes("UTF-8")) {
+      val c = (b & 0xff).toChar
       if (c == '+' && encodePlus) sb.append("%2B") // #48
       else if (allowedCharacters(c)) sb.append(c)
       else if (c == ' ' && spaceAsPlus) sb.append('+')
       else {
-        for (b <- c.toString.getBytes("UTF-8")) {
-          sb.append("%")
-          sb.append(Rfc3986Compatibility.formatByte(b))
-        }
+        sb.append("%")
+        sb.append(Rfc3986Compatibility.formatByte(b))
       }
     }
     sb.toString

--- a/core/src/test/scala/sttp/model/UriInterpolatorTests.scala
+++ b/core/src/test/scala/sttp/model/UriInterpolatorTests.scala
@@ -153,6 +153,12 @@ class UriInterpolatorTests extends AnyFunSuite with Matchers {
       (uri"${uri"http://example.com/$v1/"}/$v1", s"http://example.com/$v1/$v1"),
       (uri"${uri"http://example.com/$v1/"}/$v1/", s"http://example.com/$v1/$v1/"),
       (uri"${"http://example.com:123/a/"}/b/c", "http://example.com:123/a/b/c")
+    ),
+    "encode unicode characters that are encoded as 3+ UTF-8 bytes" -> List(
+      (uri"http://example.com/we/have/🍪", "http://example.com/we/have/%F0%9F%8D%AA"),
+      (uri"http://example.com/dont/run/with/✂", "http://example.com/dont/run/with/%E2%9C%82"),
+      (uri"http://example.com/in/query?key=🍪", "http://example.com/in/query?key=%F0%9F%8D%AA"),
+      (uri"http://example.com/in/query?🍪=value", "http://example.com/in/query?%F0%9F%8D%AA=value")
     )
   )
 


### PR DESCRIPTION
For such characters, the java `Char` which contains only the first 2
bytes cannot be converted to a valid string which result in a string
containing a single byte `0x3F`.

By iterating over the UTF-8 bytes instead of 2-byte characters, we can
handle all different cases, treating the allowed characters as the
single byte characters they are.

This can occur with some APIs, such as the Discord API, which requires the reaction emoji to be part of the path in URL-encoded form.