### PR TITLE
q value regex fix

### DIFF
--- a/core/src/main/scala/sttp/model/MediaType.scala
+++ b/core/src/main/scala/sttp/model/MediaType.scala
@@ -6,7 +6,6 @@ import sttp.model.internal.Validate._
 import sttp.model.internal.{Patterns, Validate}
 
 import java.nio.charset.Charset
-import scala.collection.immutable.Seq
 
 case class MediaType(
     mainType: String,

--- a/core/src/main/scala/sttp/model/MediaType.scala
+++ b/core/src/main/scala/sttp/model/MediaType.scala
@@ -73,6 +73,8 @@ object MediaType extends MediaTypes {
     }
 
     val (mainType, subType) = (typeSubtype.group(1), typeSubtype.group(2), typeSubtype.group(3)) match {
+      // if there are nulls indicating no main and subtype then we expect a single * (group 3)
+      // it's invalid according to rfc but is used by `HttpUrlConnection` https://bugs.openjdk.java.net/browse/JDK-8163921
       case (null, null, Wildcard) => (Wildcard, Wildcard)
       case (mainType, subType, _) => (mainType.toLowerCase, subType.toLowerCase)
     }

--- a/core/src/main/scala/sttp/model/MediaType.scala
+++ b/core/src/main/scala/sttp/model/MediaType.scala
@@ -71,8 +71,11 @@ object MediaType extends MediaTypes {
     if (!typeSubtype.lookingAt()) {
       return Left(s"""No subtype found for: "$t"""")
     }
-    val mainType = typeSubtype.group(1).toLowerCase
-    val subType = typeSubtype.group(2).toLowerCase
+
+    val (mainType, subType) = (typeSubtype.group(1), typeSubtype.group(2), typeSubtype.group(3)) match {
+      case (null, null, Wildcard) => (Wildcard, Wildcard)
+      case (mainType, subType, _) => (mainType.toLowerCase, subType.toLowerCase)
+    }
 
     val parameters = Patterns.parseMediaTypeParameters(t, offset = typeSubtype.end())
 

--- a/core/src/main/scala/sttp/model/internal/Patterns.scala
+++ b/core/src/main/scala/sttp/model/internal/Patterns.scala
@@ -12,7 +12,7 @@ private[model] object Patterns {
   private val Quoted = "\"([^\"]*)\""
 
   val Type: Pattern = Pattern.compile(s"$Token")
-  val TypeSubtype: Pattern = Pattern.compile(s"$Token/$Token")
+  val TypeSubtype: Pattern = Pattern.compile(s"$Token/$Token|([*])")
   val Parameter: Pattern = Pattern.compile(s";\\s*(?:$Token=(?:$Token|$Quoted))?")
 
   val QValue: Regex = "(0\\.?\\d{0,3}?|\\.\\d{1,3}?|1\\.0{1,3}?)".r

--- a/core/src/main/scala/sttp/model/internal/Patterns.scala
+++ b/core/src/main/scala/sttp/model/internal/Patterns.scala
@@ -15,7 +15,7 @@ private[model] object Patterns {
   val TypeSubtype: Pattern = Pattern.compile(s"$Token/$Token")
   val Parameter: Pattern = Pattern.compile(s";\\s*(?:$Token=(?:$Token|$Quoted))?")
 
-  val QValue: Regex = "(0.?\\d{0,3}?|1.?0{0,3}?)".r
+  val QValue: Regex = "(0\\.?\\d{0,3}?|\\.\\d{1,3}?|1\\.0{1,3}?)".r
   val WhiteSpaces: String = "\\s+"
 
   def parseMediaTypeParameters(t: String, offset: Int): Either[String, Map[String, String]] = {

--- a/core/src/test/scalajvm/sttp/model/headers/AcceptsTest.scala
+++ b/core/src/test/scalajvm/sttp/model/headers/AcceptsTest.scala
@@ -76,12 +76,13 @@ class AcceptsTest extends AnyFlatSpec with Matchers with TableDrivenPropertyChec
       Seq(ContentTypeRange("text", "plain", "*"))
     ),
     (
-      "text/html, image/gif, image/jpeg, */*; q=.2",
+      "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",
       "*",
       Seq(
         ContentTypeRange("text", "html", "*"),
         ContentTypeRange("image", "gif", "*"),
         ContentTypeRange("image", "jpeg", "*"),
+        ContentTypeRange("*", "*", "*"),
         ContentTypeRange("*", "*", "*")
       )
     )

--- a/core/src/test/scalajvm/sttp/model/headers/AcceptsTest.scala
+++ b/core/src/test/scalajvm/sttp/model/headers/AcceptsTest.scala
@@ -13,6 +13,9 @@ class AcceptsTest extends AnyFlatSpec with Matchers with TableDrivenPropertyChec
   private val acceptsCases = Table(
     ("Accept", "Accept-Charset", "result"),
     ("application/json", "*", Seq(ContentTypeRange("application", "json", "*"))),
+    ("application/json;q=.8", "*", Seq(ContentTypeRange("application", "json", "*"))),
+    ("application/json;q=.88", "*", Seq(ContentTypeRange("application", "json", "*"))),
+    ("application/json;q=.888", "*", Seq(ContentTypeRange("application", "json", "*"))),
     ("application/json", "utf-8", Seq(ContentTypeRange("application", "json", "utf-8"))),
     ("application/json", "utf-8;a=1;b=2;c=3", Seq(ContentTypeRange("application", "json", "utf-8"))),
     (
@@ -71,6 +74,16 @@ class AcceptsTest extends AnyFlatSpec with Matchers with TableDrivenPropertyChec
       "text/plain;q=1.000",
       "*",
       Seq(ContentTypeRange("text", "plain", "*"))
+    ),
+    (
+      "text/html, image/gif, image/jpeg, */*; q=.2",
+      "*",
+      Seq(
+        ContentTypeRange("text", "html", "*"),
+        ContentTypeRange("image", "gif", "*"),
+        ContentTypeRange("image", "jpeg", "*"),
+        ContentTypeRange("*", "*", "*")
+      )
     )
   )
 
@@ -129,6 +142,10 @@ class AcceptsTest extends AnyFlatSpec with Matchers with TableDrivenPropertyChec
       (q: String) => s"""q must be numeric value between <0, 1> with up to 3 decimal points, provided "$q""""
 
     Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=xxx"))) shouldBe Left(errorMsg("xxx"))
+    Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=."))) shouldBe Left(errorMsg("."))
+    Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=.1234"))) shouldBe Left(errorMsg(".1234"))
+    Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=1.123"))) shouldBe Left(errorMsg("1.123"))
+    Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=1."))) shouldBe Left(errorMsg("1."))
     Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=123"))) shouldBe Left(errorMsg("123"))
     Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=0.1234"))) shouldBe Left(errorMsg("0.1234"))
     Accepts.parse(Seq(Header(HeaderNames.Accept, "text/html;q=1.0000"))) shouldBe Left(errorMsg("1.0000"))


### PR DESCRIPTION
So, the `.2` is fixed for `q` value, but `text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2` from issue is still invalid, since single `*` is not valid in Accept header, subtype is missing