### PR TITLE
Add Origin and Vary headers

### DIFF
--- a/core/src/main/scala/sttp/model/Header.scala
+++ b/core/src/main/scala/sttp/model/Header.scala
@@ -8,6 +8,7 @@ import sttp.model.headers.{
   Cookie,
   CookieWithMeta,
   ETag,
+  Origin,
   Range,
   WWWAuthenticateChallenge
 }
@@ -117,6 +118,7 @@ object Header {
   def lastModified(i: Instant): Header = Header(HeaderNames.LastModified, toHttpDateString(i))
   def location(uri: String): Header = Header(HeaderNames.Location, uri)
   def location(uri: Uri): Header = Header(HeaderNames.Location, uri.toString)
+  def origin(origin: Origin): Header = Header(HeaderNames.Origin, origin.toString)
   def proxyAuthorization(authType: String, credentials: String): Header =
     Header(HeaderNames.ProxyAuthorization, s"$authType $credentials")
   def range(range: Range): Header = Header(HeaderNames.Range, range.toString)
@@ -129,7 +131,7 @@ object Header {
       otherChallenges: WWWAuthenticateChallenge*
   ): List[Header] =
     (firstChallenge :: otherChallenges.toList).map(c => Header(HeaderNames.WwwAuthenticate, c.toString))
-
+  def vary(headerNames: String*): Header = Header(HeaderNames.Vary, headerNames.mkString(", "))
   def xForwardedFor(firstAddress: String, otherAddresses: String*): Header =
     Header(HeaderNames.XForwardedFor, (firstAddress +: otherAddresses).mkString(", "))
 

--- a/core/src/main/scala/sttp/model/headers/Origin.scala
+++ b/core/src/main/scala/sttp/model/headers/Origin.scala
@@ -1,0 +1,9 @@
+package sttp.model.headers
+
+sealed trait Origin
+object Origin {
+  case object Null extends Origin { override def toString: String = "null" }
+  case class Host(scheme: String, hostname: String, port: Option[Int] = None) {
+    override def toString: String = s"$scheme://$hostname${port.map(p => s":$p").getOrElse("")}"
+  }
+}


### PR DESCRIPTION
Will be used by the CORS interceptor in tapir.

Btw. different sources suggest different syntax for `Origin` - [RFC-6454](https://datatracker.ietf.org/doc/html/rfc6454#section-7) says that it's a list of hosts, while [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) says that it's a single host. Since the CORS interceptor would assume a single value, I went for the simpler MDN approach.