### PR TITLE
Improve performance of UriInterpolator

### DIFF
--- a/benchmark/src/main/scala/sttp/model/InterpolatorBenchmark.scala
+++ b/benchmark/src/main/scala/sttp/model/InterpolatorBenchmark.scala
@@ -1,0 +1,37 @@
+package sttp.model
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import sttp.model.Uri._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 4, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 2, time = 20, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = Array("-Xms1G", "-Xmx1G", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"))
+@State(Scope.Benchmark)
+class InterpolatorBenchmark {
+
+  @Benchmark
+  def simpleUrl: Int = {
+    uri"http://example.com/some/path".path.length
+  }
+
+  @Benchmark
+  def longUrl: Int = {
+    val var1 = "path"
+    val var2 = "another"
+    val var3 = "other"
+    val var4 = "zxcv"
+    uri"http://example.com/some/$var1/$var2/$var3/$var4/123".path.length
+  }
+
+  @Benchmark
+  def urlWithQuery: Int = {
+    val value3 = "value3"
+    val value4 = "value4"
+    val value5 = "value5"
+    uri"http://example.com/some?key1=value1&key2=value2&key3=$value3&key4=$value4&key5=$value5".path.length
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -97,3 +97,15 @@ lazy val core = (projectMatrix in file("core"))
     scalaVersions = scala2 ++ scala3,
     settings = commonNativeSettings
   )
+
+lazy val benchmark = (projectMatrix in file("benchmark"))
+  .settings(
+    name := "benchmark",
+    publish / skip := true
+  )
+  .jvmPlatform(
+    scalaVersions = scala2,
+    settings = commonJvmSettings
+  )
+  .dependsOn(core)
+  .enablePlugins(JmhPlugin)

--- a/core/src/main/scala/sttp/model/UriInterpolator.scala
+++ b/core/src/main/scala/sttp/model/UriInterpolator.scala
@@ -1,12 +1,10 @@
 package sttp.model
 
-import java.util.{ArrayList, List => JList}
-
 import sttp.model.internal.{ArrayView, ParseUtils, Rfc3986, Singleton}
 
 import scala.annotation.tailrec
-import scala.collection.convert.ImplicitConversions._
 import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable.ArrayBuffer
 
 trait UriInterpolator {
   implicit class UriContext(val sc: StringContext) {
@@ -62,7 +60,7 @@ object UriInterpolator {
     val startingUri = Uri(None, None, Uri.EmptyPath, Nil, None)
 
     val (uri, leftTokens) =
-      builders.foldLeft((startingUri, ArrayView(tokens))) { case ((u, t), builder) =>
+      builders.foldLeft((startingUri, filterNulls(tokens))) { case ((u, t), builder) =>
         builder.fromTokens(u, t)
       }
 
@@ -73,11 +71,16 @@ object UriInterpolator {
     uri
   }
 
-  private def tokenize(sc: StringContext, args: Any*): Vector[Token] = {
+  private def tokenize(sc: StringContext, args: Any*): ArrayBuffer[Token] = {
     val strings = sc.parts.iterator
     val expressions = args.iterator
 
-    var (tokenizer, tokens) = Tokenizer.Scheme.tokenize(strings.next())
+    // Mutable container is chosen to make less allocations during tokenization.
+    // This buffer may contain nulls. Take into account it when accessing elements in 'tokens'.
+    // Null may appear in buffer when some token is removed from container (for example,
+    // function tokenizeStringRemoveEmptyPrefix)
+    val tokens = new ArrayBuffer[Token](32)
+    var tokenizer = Tokenizer.Scheme.tokenize(tokens, strings.next())
 
     while (strings.hasNext) {
       val nextExpression = expressions.next()
@@ -92,24 +95,20 @@ object UriInterpolator {
       // Parsing the expression as if its string value was embedded in the interpolated string. This way it's possible
       // to extend existing URIs. Without special-casing the embedded URI would be escaped and become part of the host
       // as a whole.
-      if (tokens == Vector(StringToken("")) && (nextExpressionStr.contains("://") || !nextStr.contains("://"))) {
-        def tokenizeExpressionAsString(): Unit = {
-          val (nextTokenizer, nextTokens) =
-            tokenizer.tokenize(nextExpression.toString)
-          tokenizer = nextTokenizer
-          tokens = tokens ++ nextTokens
-        }
+      if (tokens.size == 1 && tokens.startsWith(List(StringToken(""))) && (nextExpressionStr.contains("://") || !nextStr.contains("://"))) {
+        def tokenizeExpressionAsString(): Unit =
+          tokenizer = tokenizer.tokenize(tokens, nextExpression.toString)
 
         def tokenizeStringRemoveEmptyPrefix(): Unit = {
-          val (nextTokenizer, nextTokens) = tokenizer.tokenize(nextStr)
-          tokenizer = nextTokenizer
+          val initLength = tokens.size
+          tokenizer = tokenizer.tokenize(tokens, nextStr)
 
           // we need to remove empty tokens around exp as well - however here
           // by hand, as the expression token is unwrapped, so removeEmptyTokensAroundExp
           // won't handle this.
-          val nextTokensWithoutEmptyPrefix = nextTokens match {
-            case StringToken("") +: tail => tail
-            case x                       => x
+          if (initLength < tokens.size && tokens(initLength) == emptyStringToken) {
+            // just assign tombstone to avoid moving the rest of tokens
+            tokens.update(initLength, null)
           }
 
           def isSlash(t: Token) = t == SlashInPath || t == PathStart
@@ -117,25 +116,29 @@ object UriInterpolator {
           // remove trailing slash when path is added to an interpolated uri:
           // val a = uri"http://example.com/" // notice the trailing slash
           // val b = uri"$a/xy" // "http://example.com/xy"
-          (tokens, nextTokensWithoutEmptyPrefix) match {
-            case (ts :+ t :+ StringToken(""), SlashInPath +: nt) if isSlash(t) => tokens = ts ++ (t +: nt)
-            case _ => tokens = tokens ++ nextTokensWithoutEmptyPrefix
+          for {
+            (slashInPathIdx, _) <- nextNonNull(tokens, initLength).filter(_._2 == SlashInPath)
+            (emptyStringTokenIdx, _) <- lastNonNull(tokens, initLength - 1).filter(_._2 == StringToken(""))
+            _ <- lastNonNull(tokens, emptyStringTokenIdx - 1).filter(tuple => isSlash(tuple._2))
+          } {
+            tokens.update(slashInPathIdx, null)
+            tokens.update(emptyStringTokenIdx, null)
           }
         }
 
         tokenizeExpressionAsString()
         tokenizeStringRemoveEmptyPrefix()
       } else {
-        tokens = tokens :+ ExpressionToken(nextExpression)
+        tokens += ExpressionToken(nextExpression)
 
-        val (nextTokenizer, nextTokens) = tokenizer.tokenize(nextStr)
-        tokenizer = nextTokenizer
-        tokens = tokens ++ nextTokens
+        tokenizer = tokenizer.tokenize(tokens, nextStr)
       }
     }
 
-    val tokensWithEndToken = tokens ++ tokenizer.endToken.toVector
-    addPathStartAfterAuthorityOrSchemeEnd(removeEmptyTokensAroundExp(tokensWithEndToken))
+    tokenizer.endToken.foreach(tokens += _)
+    removeEmptyTokensAroundExp(tokens)
+    addPathStartAfterAuthorityOrSchemeEnd(tokens)
+    tokens
   }
 
   sealed trait Token
@@ -153,32 +156,47 @@ object UriInterpolator {
   case object EqInQuery extends Token
   case object FragmentStart extends Token
 
-  trait Tokenizer {
-    def tokenize(s: String): (Tokenizer, Vector[Token])
+  private[model] sealed trait Tokenizer {
+    // Tokenizes string 's' into tokens. New tokens are added into mutable
+    // scala.collection.mutable.ArrayBuffer 'buffer'.
+    // Returns tokenizer which can handle continuation of URI.
+    def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer
+    def tokenize(s: String): (Tokenizer, Vector[Token]) = {
+      val buffer = new ArrayBuffer[Token]()
+      val tokenizer = tokenize(buffer, s)
+      val b = new VectorBuilder[Token]()
+      b.sizeHint(buffer.size)
+      buffer.foreach(b += _)
+      (tokenizer, b.result())
+    }
     def endToken: Option[Token] = None // token to add if the input is exhausted
   }
 
-  object Tokenizer {
+  private object Tokenizer {
     private val AuthorityTerminators = Set('/', '?', '#')
 
     object Scheme extends Tokenizer {
       private val SchemePattern = "[A-Za-z][A-Za-z0-9+.-]*".r
 
-      override def tokenize(s: String): (Tokenizer, Vector[Token]) = {
+      override def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer = {
         SchemePattern.findPrefixOf(s) match {
           // #59: if the entire string matches the pattern, then there's no scheme terminator (`:`). This means there's
           // no scheme, hence - tokenizing as a relative uri.
-          case Some(scheme) if scheme.length == s.length => AfterScheme.tokenize(scheme)
-          case _ if s.isEmpty => (this, Vector(StringToken(""))) // scheme (or another component) might be continued
+          case Some(scheme) if scheme.length == s.length => AfterScheme.tokenize(buffer, scheme)
+          case _ if s.isEmpty =>
+            // scheme (or another component) might be continued
+            buffer += StringToken("")
+            this
           case Some(scheme) if s(scheme.length) == ':' =>
             val rest = s.substring(scheme.length + 1)
-            val (next, afterSchemeTokens) = AfterScheme.tokenize(rest)
-            (next, Vector(StringToken(scheme), SchemeEnd) ++ afterSchemeTokens)
+            buffer += StringToken(scheme)
+            buffer += SchemeEnd
+            AfterScheme.tokenize(buffer, rest)
           case _ if s.startsWith(":") => // there was an expression token before, end of scheme
-            val (next, tokens) = AfterScheme.tokenize(s.substring(1))
-            (next, SchemeEnd +: tokens)
+            buffer += SchemeEnd
+            AfterScheme.tokenize(buffer, s.substring(1))
           case _ => // no scheme
-            AfterScheme.tokenize(s)
+            AfterScheme.tokenize(buffer, s)
         }
       }
 
@@ -186,23 +204,28 @@ object UriInterpolator {
     }
 
     object AfterScheme extends Tokenizer {
-      override def tokenize(s: String): (Tokenizer, Vector[Token]) = {
-        if (s == "") (this, Vector(StringToken("")))
-        else if (s.startsWith("//")) Authority.tokenize(s.substring(2)) // uri with authority
-        else { // uri without authority
+      override def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer = {
+        if (s == "") {
+          buffer += StringToken("")
+          this
+        } else if (s.startsWith("//")) {
+          Authority.tokenize(buffer, s.substring(2)) // uri with authority
+        } else { // uri without authority
           val first = s(0)
           if (AuthorityTerminators.contains(first)) {
             val (tokenizer, token) = separatorTokenizerAndToken(first)
-            val tokens1 = if (token == PathStart) {
+            if (token == PathStart) {
               // absolute path in a relative uri, adding an empty string token so that the absolute path is preserved
               // (might be a continuation if there was no scheme)
-              Vector(StringToken(""), SlashInPath)
-            } else Vector(token)
-            val (tokenizer2, tokens2) = tokenizer.tokenize(s.substring(1))
-            (tokenizer2, tokens1 ++ tokens2)
+              buffer += StringToken("")
+              buffer += SlashInPath
+            } else {
+              buffer += token
+            }
+            tokenizer.tokenize(buffer, s.substring(1))
           } else {
             // non-slash-initiated path (might be a continuation if there was no scheme)
-            Path.tokenize(s)
+            Path.tokenize(buffer, s)
           }
         }
       }
@@ -211,49 +234,57 @@ object UriInterpolator {
     object Authority extends Tokenizer {
       private val IpV6InAuthorityPattern = "\\[[0-9a-fA-F:]+\\]".r // see the pattern in Uri.HostEncoding
 
-      override def tokenize(s: String): (Tokenizer, Vector[Token]) = {
-        val (tokenizer, tokens) = tokenizeTerminatedFragment(
+      override def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer = {
+        val initSize = buffer.size
+        val tokenizer = tokenizeTerminatedFragment(
           s,
           this,
+          buffer,
           Set('/', '?', '#'),
           Map(':' -> ColonInAuthority, '@' -> AtInAuthority, '.' -> DotInAuthority),
           Some(('[', ']'))
         )
-        val tokens2 = tokens.map {
-          case StringToken(s @ IpV6InAuthorityPattern()) =>
-            // removing the [] which are used to surround ipv6 addresses in URLs
-            StringToken(s.substring(1, s.length - 1))
-          case t => t
+        (initSize until buffer.size).foreach { idx =>
+          buffer(idx) match {
+            case StringToken(s @ IpV6InAuthorityPattern()) =>
+              buffer.update(idx, StringToken(s.substring(1, s.length() - 1)))
+            case _ => ()
+          }
         }
-        (tokenizer, tokens2)
+        tokenizer
       }
 
       override def endToken: Option[Token] = Some(AuthorityEnd)
     }
 
     object Path extends Tokenizer {
-      override def tokenize(s: String): (Tokenizer, Vector[Token]) =
+      override def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer =
         tokenizeTerminatedFragment(
           s,
           this,
+          buffer,
           Set('?', '#'),
           Map('/' -> SlashInPath)
         )
     }
 
     object Query extends Tokenizer {
-      override def tokenize(s: String): (Tokenizer, Vector[Token]) =
+      override def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer =
         tokenizeTerminatedFragment(
           s,
           this,
+          buffer,
           Set('#'),
-          Map('&' -> AmpInQuery, '=' -> EqInQuery)
+          Map('&' -> AmpInQuery, '=' -> EqInQuery),
+          None
         )
     }
 
     object Fragment extends Tokenizer {
-      override def tokenize(s: String): (Tokenizer, Vector[Token]) =
-        (this, Vector(StringToken(s)))
+      override def tokenize(buffer: ArrayBuffer[Token], s: String): Tokenizer = {
+        buffer += StringToken(s)
+        this
+      }
     }
 
     /** Tokenize the given string up to any of the given terminator characters by splitting it using the given
@@ -268,15 +299,19 @@ object UriInterpolator {
     private def tokenizeTerminatedFragment(
         s: String,
         current: Tokenizer,
+        buffer: ArrayBuffer[Token],
         terminators: Set[Char],
         separatorsToTokens: Map[Char, Token],
         separatorsEscape: Option[(Char, Char)] = None
-    ): (Tokenizer, Vector[Token]) = {
-      def tokenizeFragment(f: String): Vector[Token] = {
-        splitPreserveSeparators(f, separatorsToTokens.keySet, separatorsEscape).map { t =>
-          t.headOption.flatMap(separatorsToTokens.get) match {
-            case Some(token) => token
-            case None        => StringToken(t)
+    ): Tokenizer = {
+      def tokenizeFragment(f: String): Unit = {
+        val initLength = buffer.size
+        splitPreserveSeparators(buffer, f, separatorsToTokens.keySet, separatorsEscape)
+        (initLength until buffer.size).foreach { idx =>
+          buffer(idx) match {
+            case StringToken(s) =>
+              s.headOption.flatMap(separatorsToTokens.get).foreach(buffer.update(idx, _))
+            case _ => ()
           }
         }
       }
@@ -287,21 +322,24 @@ object UriInterpolator {
       // See: https://tools.ietf.org/html/rfc3986#section-3.2
       split(s, terminators, None) match {
         case Right((fragment, separator, rest)) =>
-          tokenizeAfterSeparator(tokenizeFragment(fragment) ++ current.endToken.toVector, separator, rest)
+          tokenizeFragment(fragment)
+          current.endToken.foreach(buffer += _)
+          tokenizeAfterSeparator(buffer, separator, rest)
 
         case Left(fragment) =>
-          (current, tokenizeFragment(fragment))
+          tokenizeFragment(fragment)
+          current
       }
     }
 
     private def tokenizeAfterSeparator(
-        beforeSeparatorTokens: Vector[Token],
+        acc: ArrayBuffer[Token],
         separator: Char,
         s: String
-    ): (Tokenizer, Vector[Token]) = {
+    ): Tokenizer = {
       val (next, separatorToken) = separatorTokenizerAndToken(separator)
-      val (nextNext, nextTokens) = next.tokenize(s)
-      (nextNext, beforeSeparatorTokens ++ Vector(separatorToken) ++ nextTokens)
+      acc += separatorToken
+      next.tokenize(acc, s)
     }
 
     private def separatorTokenizerAndToken(separator: Char): (Tokenizer, Token) =
@@ -311,17 +349,21 @@ object UriInterpolator {
         case '#' => (Fragment, FragmentStart)
       }
 
-    private def splitPreserveSeparators(s: String, sep: Set[Char], escape: Option[(Char, Char)]): Vector[String] = {
+    private def splitPreserveSeparators(acc: ArrayBuffer[Token], s: String, sep: Set[Char], escape: Option[(Char, Char)]): Unit = {
       @tailrec
-      def doSplit(s: String, acc: Vector[String]): Vector[String] = {
+      def doSplit(s: String): Unit = {
         split(s, sep, escape) match {
-          case Left(x) => acc :+ x
+          case Left(x) =>
+            acc += StringToken(x)
+            ()
           case Right((before, separator, after)) =>
-            doSplit(after, acc ++ Vector(before, separator.toString))
+            acc += StringToken(before)
+            acc += StringToken(separator.toString())
+            doSplit(after)
         }
       }
 
-      doSplit(s, Vector.empty)
+      doSplit(s)
     }
 
     private def split(
@@ -710,39 +752,84 @@ object UriInterpolator {
     *
     * These empty string tokens need to be removed so that e.g. extra key-value mappings are not generated.
     */
-  private def removeEmptyTokensAroundExp(tokens: Vector[Token]): Vector[Token] = {
-    @tailrec
-    def doRemove(t: Vector[Token], acc: Vector[Token]): Vector[Token] =
-      t match {
-        case StringToken("") +: (e: ExpressionToken) +: tail => doRemove(e +: tail, acc)
-        case (e: ExpressionToken) +: StringToken("") +: tail => doRemove(tail, acc :+ e)
-        case v +: tail                                       => doRemove(tail, acc :+ v)
-        case _ /* empty */                                   => acc
+  private def removeEmptyTokensAroundExp(tokens: ArrayBuffer[Token]): Unit = {
+    var prevWasEmptyString = false
+    var prevWasExpression = false
+    (0 until tokens.size).foreach { idx =>
+      tokens(idx) match {
+        case StringToken("") =>
+          // if previous token was expression then remove current one (empty string)
+          if (prevWasExpression) {
+            tokens.update(idx, null)
+            prevWasExpression = false
+          } else {
+            prevWasEmptyString = true
+          }
+        case ExpressionToken(_) =>
+          // if previous token was empty string then remove it because current token is expression
+          if (prevWasEmptyString) {
+            tokens.update(idx - 1, null)
+            prevWasEmptyString = false
+          }
+          prevWasExpression = true
+        case null =>
+          ()
+        case _ =>
+          prevWasExpression = false
+          prevWasEmptyString = false
       }
-
-    doRemove(tokens, Vector.empty)
+    }
   }
 
   /** In relative URIs or URIs without authority, there might be no explicit path start (`/`). Adding it so that the
     * second pass of parsing can depend on the `PathStart` token being available.
     */
-  private def addPathStartAfterAuthorityOrSchemeEnd(tokens: Vector[Token]): Vector[Token] = {
+  private def addPathStartAfterAuthorityOrSchemeEnd(tokens: ArrayBuffer[Token]): Unit = {
     val endIndex = tokens.indexOf(AuthorityEnd) match {
       case -1 => tokens.indexOf(SchemeEnd)
       case n  => n
     }
 
-    if (endIndex + 1 == tokens.length) {
-      tokens // no path, query or fragment at all
-    } else {
-      val afterEndIndex = tokens(endIndex + 1)
+    nextNonNull(tokens, endIndex + 1).foreach { case (_, afterEndIndex) =>
       if (afterEndIndex != PathStart && afterEndIndex != QueryStart && afterEndIndex != FragmentStart) {
         // no start token after authority/scheme end - inserting
-        val (init, tail) = if (endIndex == -1) (Vector.empty, tokens) else tokens.splitAt(endIndex + 1)
-        init ++ Vector(PathStart) ++ tail
-      } else {
-        tokens
+        if (endIndex == -1) {
+          tokens.prepend(PathStart)
+        } else {
+          tokens.insert(endIndex + 1, PathStart)
+        }
       }
+    }
+  }
+
+  private def filterNulls(tokens: ArrayBuffer[Token]): ArrayView[Token] = {
+    val array = new Array[Token](tokens.size)
+    var i = 0
+    tokens.foreach { token =>
+      if (token != null) {
+        array.update(i, token)
+        i += 1
+      }
+    }
+
+    new ArrayView(array, 0, i)
+  }
+
+  private def lastNonNull[T](tokens: ArrayBuffer[T], from: Int): Option[(Int, T)] = {
+    val idx = tokens.lastIndexWhere(_ != null, from)
+    if (idx == -1) {
+      None
+    } else {
+      Some((idx, tokens(idx)))
+    }
+  }
+
+  private def nextNonNull[T](tokens: ArrayBuffer[T], from: Int): Option[(Int, T)] = {
+    val idx = tokens.indexWhere(_ != null, from)
+    if (idx == -1) {
+      None
+    } else {
+      Some((idx, tokens(idx)))
     }
   }
 }

--- a/core/src/main/scala/sttp/model/UriInterpolator.scala
+++ b/core/src/main/scala/sttp/model/UriInterpolator.scala
@@ -144,20 +144,20 @@ object UriInterpolator {
     tokens
   }
 
-  sealed trait Token
-  case class StringToken(s: String) extends Token
-  case class ExpressionToken(e: Any) extends Token
-  case object SchemeEnd extends Token
-  case object ColonInAuthority extends Token
-  case object AtInAuthority extends Token
-  case object DotInAuthority extends Token
-  case object AuthorityEnd extends Token
-  case object PathStart extends Token
-  case object SlashInPath extends Token
-  case object QueryStart extends Token
-  case object AmpInQuery extends Token
-  case object EqInQuery extends Token
-  case object FragmentStart extends Token
+  private[model] sealed trait Token
+  private[model] case class StringToken(s: String) extends Token
+  private[model] case class ExpressionToken(e: Any) extends Token
+  private[model] case object SchemeEnd extends Token
+  private[model] case object ColonInAuthority extends Token
+  private[model] case object AtInAuthority extends Token
+  private[model] case object DotInAuthority extends Token
+  private[model] case object AuthorityEnd extends Token
+  private[model] case object PathStart extends Token
+  private[model] case object SlashInPath extends Token
+  private[model] case object QueryStart extends Token
+  private[model] case object AmpInQuery extends Token
+  private[model] case object EqInQuery extends Token
+  private[model] case object FragmentStart extends Token
 
   private[model] sealed trait Tokenizer {
     // Tokenizes string 's' into tokens. New tokens are added into mutable

--- a/core/src/main/scala/sttp/model/internal/ArrayView.scala
+++ b/core/src/main/scala/sttp/model/internal/ArrayView.scala
@@ -155,7 +155,7 @@ private[model] class ArrayView[T](arr: Array[T], from: Int, till: Int) {
 
   override def toString: String = {
     val list = new ArrayList[T](size)
-    foreach(list.add(_): Unit)
+    foreach(list.add(_))
     list.toString()
   }
 }

--- a/core/src/main/scala/sttp/model/internal/ArrayView.scala
+++ b/core/src/main/scala/sttp/model/internal/ArrayView.scala
@@ -1,0 +1,178 @@
+package sttp.model.internal
+
+import java.lang.StringBuilder
+import java.util.ArrayList
+
+import scala.reflect.ClassTag
+import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable.ArrayBuilder
+
+// ArrayView is just wrapper for Array. It has fast methods 'take', 'drop', 'span' which
+// requires only one allocation on heap. These methods are heavily used by UriBuilder.
+private[model] class ArrayView[T](arr: Array[T], from: Int, till: Int) {
+
+  def isEmpty: Boolean =
+    till <= from
+
+  def nonEmpty: Boolean =
+    from < till
+
+  def get(i: Int): T =
+    arr(from + i)
+
+  def size: Int =
+    till - from
+
+  def headOption: Option[T] =
+    if (nonEmpty) {
+      Some(arr(from))
+    } else {
+      None
+    }
+
+  def startsWith(t: T): Boolean =
+    nonEmpty && arr(from) == t
+
+  def lastOption: Option[T] =
+    if (nonEmpty) {
+      Some(arr(till - 1))
+    } else {
+      None
+    }
+
+  def foreach(func: T => Unit): Unit = {
+    var i = from
+    while (i < till) {
+      func(arr(i))
+      i += 1
+    }
+  }
+
+  def map[U: ClassTag](func: T => U): ArrayView[U] = {
+    val newArray = new Array[U](size)
+    var i = 0
+    while (i < newArray.size) {
+      newArray.update(i, func(arr(i + from)))
+      i += 1
+    }
+    new ArrayView(newArray, 0, newArray.size)
+  }
+
+  def flatMapLike(func: T => List[T])(implicit ev: ClassTag[T]): ArrayView[T] = {
+    val b = ArrayBuilder.make[T]
+    b.sizeHint(2 * size)
+    foreach(t => func(t).foreach(b += _))
+    val result = b.result()
+    new ArrayView(result, 0, result.length)
+  }
+
+  def count(pred: T => Boolean): Int = {
+    var result: Int = 0
+    foreach(t => if (pred(t)) result += 1)
+    result
+  }
+
+  def mkString(transform: T => String): String = {
+    val sb = new StringBuilder(128)
+    var i = from
+    while (i < till) {
+      sb.append(transform(arr(i)))
+      i += 1
+    }
+    sb.toString()
+  }
+
+  def mkStringOpt(transform: T => Option[String]): Option[String] = {
+    val sb = new StringBuilder(128)
+    var empty: Boolean = true
+    var i = from
+    while (i < till) {
+      transform(arr(i)).foreach { str =>
+        sb.append(str)
+        empty = false
+      }
+      i += 1
+    }
+    if (empty) None else Some(sb.toString())
+  }
+
+  def indexOf(t: T): Int = {
+    var i = from
+    while (i < till && arr(i) != t) {
+      i += 1
+    }
+    if (i == till) -1 else i - from
+  }
+
+  def indexWhere(pred: T => Boolean): Int = {
+    var i = from
+    while (i < till && !pred(arr(i))) {
+      i += 1
+    }
+    if (i == till) -1 else i - from
+  }
+
+  def take(i: Int): ArrayView[T] =
+    new ArrayView(arr, from, from + i)
+
+  def drop(i: Int): ArrayView[T] =
+    new ArrayView(arr, from + i, till)
+
+  def dropWhile(pred: T => Boolean): ArrayView[T] = {
+    var i = from
+    val len = arr.length
+    while (i < len && pred(arr(i))) {
+      i += 1
+    }
+    new ArrayView(arr, i, till)
+  }
+
+  def span(pred: T => Boolean): (ArrayView[T], ArrayView[T]) = {
+    var i = from
+    while (i < till && pred(arr(i))) {
+      i += 1
+    }
+    (new ArrayView(arr, from, i), new ArrayView(arr, i + 1, till))
+  }
+
+  def shiftLeft: ArrayView[T] =
+    new ArrayView(arr, from - 1, till)
+
+  def +:(t: T)(implicit ev: ClassTag[T]): ArrayView[T] = {
+    val currentSize = size
+    val newArr = new Array[T](currentSize + 1)
+    newArr.update(0, t)
+    Array.copy(arr, from, newArr, 1, currentSize)
+    new ArrayView(newArr, 0, currentSize + 1)
+  }
+
+  def toVector: Vector[T] = {
+    val b = new VectorBuilder[T]()
+    b.sizeHint(size)
+    foreach(b += _)
+    b.result()
+  }
+
+  override def toString: String = {
+    val list = new ArrayList[T](size)
+    foreach(list.add(_): Unit)
+    list.toString()
+  }
+}
+
+object ArrayView {
+
+  def empty[T: ClassTag]: ArrayView[T] =
+    new ArrayView[T](Array.empty[T], 0, 0)
+
+  def apply[T: ClassTag](v: Vector[T]): ArrayView[T] = {
+    val arr = v.toArray
+    new ArrayView(arr, 0, arr.size)
+  }
+}
+
+object Singleton {
+
+  def unapply[T](v: ArrayView[T]): Option[T] =
+    if (v.size == 1) Some(v.get(0)) else None
+}

--- a/core/src/main/scala/sttp/model/internal/FastCharSet.scala
+++ b/core/src/main/scala/sttp/model/internal/FastCharSet.scala
@@ -1,0 +1,53 @@
+package sttp.model.internal
+
+// Immutable set with characters. Should only be used for
+// "small" characters (characters with small charcode).
+// Main advantage of this class over plain scala Set is that
+// it has better performance. Probably because it does less
+// auto-boxing.
+private[model] case class FastCharSet(set: Set[Char]) {
+
+  private val (maxCode, array) = {
+    val codes = set.map(_.toInt)
+    val maxCode = codes.max
+    val array = new Array[Boolean](maxCode + 1)
+    codes.foreach { code =>
+      array.update(code, true)
+    }
+    (maxCode, array)
+  }
+
+  def contains(ch: Char): Boolean = {
+    val code = ch.toInt
+    if (code <= maxCode) {
+      array(code)
+    } else {
+      false
+    }
+  }
+}
+
+private[model] case class FastCharMap[V](map: Map[Char, V]) {
+
+  private val (maxCode, array) = {
+    val codes = map.map { case (key, value) => (key.toInt, value) }
+    val maxCode = codes.maxBy(_._1)._1
+    val array = Array.fill[Option[V]](maxCode + 1)(None)
+    codes.foreach { case (code, value) =>
+      array.update(code, Some(value))
+    }
+    (maxCode, array)
+  }
+
+  def get(ch: Char): Option[V] = {
+    val code = ch.toInt
+    if (code <= maxCode) {
+      array(code)
+    } else {
+      None
+    }
+  }
+
+  val keySet: FastCharSet =
+    FastCharSet(map.keySet)
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-browser-tes
 
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")


### PR DESCRIPTION
This is pull request for https://github.com/softwaremill/sttp-model/issues/196.

I split my pull request into three commits:

1. First commit replaces `Vector` in `UriBuilder`s by `sttp.model.internal.ArrayView`. This allows to build `Uri` using one array (without allocations many Vectors inside each `UriBuilder`)
2. Second commit replaces `Vector` in `Tokenizer`s by `java.util.ArrayList`. Again this allows to tokenize string using one or two `ArrayList`.
3. Third commit replaces `Set` by `sttp.model.internal.FastCharSet`. Call `Set.contains(char)` leads to boxing of character which is slower than call `FastCharSet.contains(char)`. In this commit I also replaced regular expressions by custom code based on `FastCharSet`. This also improved performance.

Here is results of JMH benchmarks:
```
Without any changes
[info] Benchmark                           Mode  Cnt  Score   Error  Units
[info] InterpolatorBenchmark.longUrl       avgt    2  0,195           s/op
[info] InterpolatorBenchmark.simpleUrl     avgt    2  0,108           s/op
[info] InterpolatorBenchmark.urlWithQuery  avgt    2  0,305           s/op

With ArrayView
[info] Benchmark                           Mode  Cnt  Score   Error  Units
[info] InterpolatorBenchmark.longUrl       avgt    2  0,146           s/op
[info] InterpolatorBenchmark.simpleUrl     avgt    2  0,079           s/op
[info] InterpolatorBenchmark.urlWithQuery  avgt    2  0,241           s/op

With ArrayList
[info] Benchmark                           Mode  Cnt  Score   Error  Units
[info] InterpolatorBenchmark.longUrl       avgt    2  0,094           s/op
[info] InterpolatorBenchmark.simpleUrl     avgt    2  0,059           s/op
[info] InterpolatorBenchmark.urlWithQuery  avgt    2  0,165           s/op

With FastCharSet
[info] Benchmark                           Mode  Cnt  Score   Error  Units
[info] InterpolatorBenchmark.longUrl       avgt    2  0,052           s/op
[info] InterpolatorBenchmark.simpleUrl     avgt    2  0,030           s/op
[info] InterpolatorBenchmark.urlWithQuery  avgt    2  0,079           s/op
```