### PR TITLE
Update from idn11 to idn2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
           ~/.ivy2/cache
           ~/.coursier
         key: sbt-cache-${{ runner.os }}-${{ hashFiles('project/build.properties') }}
-    - name: Install libidn11-dev
+    - name: Install libidn2-dev
       run: |
         sudo apt-get update
-        sudo apt-get install libidn11-dev
+        sudo apt-get install libidn2-dev
     - name: Compile
       run: sbt -v compile
     - name: Test

--- a/core/src/main/scalanative/sttp/model/internal/idn/CIdn.scala
+++ b/core/src/main/scalanative/sttp/model/internal/idn/CIdn.scala
@@ -2,15 +2,15 @@ package sttp.model.internal.idn
 
 import scala.scalanative.unsafe.{CInt, CString, Ptr, extern, link, name}
 
-@link("idn")
+@link("idn2")
 @extern
 private[idn] object CIdn {
-  @name("idna_to_ascii_8z")
+  @name("idn2_to_ascii_8z")
   def toAscii(input: CString, output: Ptr[CString], flags: CInt): CInt = extern
 
-  @name("idna_strerror")
+  @name("idn2_strerror")
   def errorMsg(rc: CInt): CString = extern
 
-  @name("idn_free")
+  @name("idn2_free")
   def free(ptr: Ptr[_]): Unit = extern
 }


### PR DESCRIPTION
idn11 is not present in vcpkg's repository, which is one of the ways to static link applications with Scala Native using https://github.com/indoorvivants/sbt-vcpkg
Since idn2 is present and it's the newest version of the library, this PR updates `sttp.model.internal.idn.CIdn` to use idn2