### PR TITLE
"Instant" format according to rfc1123-date1

### DIFF
--- a/core/src/main/scala/sttp/model/Header.scala
+++ b/core/src/main/scala/sttp/model/Header.scala
@@ -143,9 +143,9 @@ object Header {
   private lazy val Rfc850DatetimePattern = "dd-MMM-yyyy HH:mm:ss zzz"
   private lazy val Rfc850DatetimeFormat = DateTimeFormatter.ofPattern(Rfc850DatetimePattern, Locale.US)
 
-  val Rfc850WeekDays = Set("mon", "tue", "wed", "thu", "fri", "sat", "sun")
-  val Rfc1123WeekDays: Array[String] = Array("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
-  val Rfc1123Months: Array[String] = Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
+  val Rfc850WeekDays = Set("mon", "tue", "wed", "thu", "fri", "sat", "sun") // not private b/c of bin-compat
+  private val Rfc1123WeekDays: Array[String] = Array("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+  private val Rfc1123Months: Array[String] = Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
     "Aug", "Sep", "Oct", "Nov", "Dec")
 
   private def parseRfc850DateTime(v: String): Instant = {

--- a/core/src/main/scala/sttp/model/Header.scala
+++ b/core/src/main/scala/sttp/model/Header.scala
@@ -144,6 +144,9 @@ object Header {
   private lazy val Rfc850DatetimeFormat = DateTimeFormatter.ofPattern(Rfc850DatetimePattern, Locale.US)
 
   val Rfc850WeekDays = Set("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+  val Rfc1123WeekDays: Array[String] = Array("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+  val Rfc1123Months: Array[String] = Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
+    "Aug", "Sep", "Oct", "Nov", "Dec")
 
   private def parseRfc850DateTime(v: String): Instant = {
     val expiresParts = v.split(", ")
@@ -165,5 +168,16 @@ object Header {
     }
   def unsafeParseHttpDate(s: String): Instant = parseHttpDate(s).getOrThrow
 
-  def toHttpDateString(i: Instant): String = DateTimeFormatter.RFC_1123_DATE_TIME.format(i.atZone(GMT))
+  def toHttpDateString(instantTime: Instant): String = {
+    val dateTime = instantTime.atZone(GMT)
+    val dayOfWeek = Rfc1123WeekDays(dateTime.getDayOfWeek.getValue - 1)
+    val month = Rfc1123Months(dateTime.getMonth.getValue - 1)
+    val dayOfMonth = dateTime.getDayOfMonth
+    val year = dateTime.getYear
+    val hour = dateTime.getHour
+    val minute = dateTime.getMinute
+    val second = dateTime.getSecond
+
+    f"$dayOfWeek, $dayOfMonth%02d $month $year%04d $hour%02d:$minute%02d:$second%02d GMT"
+  }
 }

--- a/core/src/test/scalajvm/sttp/model/HeaderTests.scala
+++ b/core/src/test/scalajvm/sttp/model/HeaderTests.scala
@@ -4,9 +4,16 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.model.headers.CacheDirective
 
+import java.time.{ Instant, LocalDateTime, ZoneId, ZonedDateTime }
 import scala.concurrent.duration.DurationInt
 
 class HeaderTests extends AnyFlatSpec with Matchers {
+  val rfc1123DatetimeFormatted = "Wed, 08 Feb 2023 02:03:04 GMT"
+
+  val rfc1123DatetimeToBeChecked: Instant = Instant.from {
+    ZonedDateTime.of(LocalDateTime.of(2023, 2, 8, 2, 3, 4), ZoneId.of("Z"))
+  }
+
   it should "return a string description of the header" in {
     Header.unsafeApply(HeaderNames.Authorization, "xyz").toString shouldBe "Authorization: xyz"
   }
@@ -34,5 +41,13 @@ class HeaderTests extends AnyFlatSpec with Matchers {
     Header
       .cacheControl(CacheDirective.NoTransform, CacheDirective.Public, CacheDirective.SMaxage(10.seconds))
       .toString shouldBe "Cache-Control: no-transform, public, s-maxage=10"
+  }
+
+  "Instant" should "be formatted according to rfc1123-date1 with a leading zero for single-digit dates" in {
+    Header.toHttpDateString(rfc1123DatetimeToBeChecked) shouldBe rfc1123DatetimeFormatted
+  }
+
+  "rfc1123-date1" should "be parsed correctly" in {
+    Header.parseHttpDate(rfc1123DatetimeFormatted) shouldBe Right(rfc1123DatetimeToBeChecked)
   }
 }

--- a/core/src/test/scalajvm/sttp/model/headers/CookieTest.scala
+++ b/core/src/test/scalajvm/sttp/model/headers/CookieTest.scala
@@ -7,7 +7,7 @@ import java.time.{ZoneId, ZonedDateTime}
 
 class CookieTest extends AnyFlatSpec with Matchers {
   val parseCookieData = List(
-    "user_id=5; Expires=Fri, 5 Oct 2018 14:28:00 GMT; Secure; HttpOnly" -> Right(
+    "user_id=5; Expires=Fri, 05 Oct 2018 14:28:00 GMT; Secure; HttpOnly" -> Right(
       CookieWithMeta.unsafeApply(
         "user_id",
         "5",
@@ -81,7 +81,7 @@ class CookieTest extends AnyFlatSpec with Matchers {
       secure = true,
       httpOnly = true,
       sameSite = Some(Cookie.SameSite.Strict)
-    ) -> "user_id=5; Expires=Fri, 5 Oct 2018 14:28:00 GMT; Secure; HttpOnly; SameSite=Strict",
+    ) -> "user_id=5; Expires=Fri, 05 Oct 2018 14:28:00 GMT; Secure; HttpOnly; SameSite=Strict",
     CookieWithMeta.unsafeApply(
       "x",
       "y",


### PR DESCRIPTION
To make http4s able to parse datetime values, the formatting of these values has to be done according to rfc1123-date1 with a leading zero for single-digit dates