### PR TITLE
optimization: cache ClassTag[Token] to avoid thread blocking

### DIFF
--- a/core/src/main/scala/sttp/model/UriInterpolator.scala
+++ b/core/src/main/scala/sttp/model/UriInterpolator.scala
@@ -5,6 +5,7 @@ import sttp.model.internal.{ArrayView, FastCharSet, FastCharMap, ParseUtils, Rfc
 import scala.annotation.tailrec
 import scala.collection.immutable.VectorBuilder
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 trait UriInterpolator {
   implicit class UriContext(val sc: StringContext) {
@@ -42,6 +43,10 @@ trait UriInterpolator {
 object UriInterpolator {
 
   private val startingUri = Uri(None, None, Uri.EmptyPath, Nil, None)
+
+  // Dynamic class tag resultion uses `synchronized` and can block threads.
+  // Cache the class tag locally to avoid it.
+  private implicit val tokenClassTag: ClassTag[Token] = ClassTag(classOf[Token])
 
   private val builders = List(
     UriBuilder.Scheme,


### PR DESCRIPTION
## Problem

I'm working on a Tapir module for [Kyo](https://github.com/getkyo/kyo/tree/main/kyo-tapir/src/main/scala/kyo) and noticed that there's some thread blocking to materialize `ClassTag`s in `UriInterpolator`. It seems a mild problem that should affect mostly benchmarks but there could be pathological scenarios with more complex routing that make it more problematic:

![sttp-baseline](https://github.com/softwaremill/sttp-model/assets/831175/ac99081f-fb8a-44d5-8ec6-ef0a6c69e6b4)

## Solution

Cache the `ClassTag` in a local field to avoid the synchronized cache lookup. The change avoids the blocking in `UriInterpolator` but there are still other cases that arise from other collection operations:

![sttp-optimized](https://github.com/softwaremill/sttp-model/assets/831175/79b0a97a-cea7-41af-8b32-beb57d548d44)

## Notes

- As an alternative users could disable the `ClassTag` cache via `-Dscala.reflect.classtag.cache.disable=true` but it could have a performance penalty.
- If there's an interest, I could explore ways to avoid the remaining sources of blocking.