### PR TITLE
Fix matching content type range parameters in presence of wildcards

### DIFF
--- a/core/src/main/scala/sttp/model/MediaType.scala
+++ b/core/src/main/scala/sttp/model/MediaType.scala
@@ -25,8 +25,8 @@ case class MediaType(
       (range.mainType == Wildcard || mainType.equalsIgnoreCase(range.mainType) &&
         (range.subType == Wildcard || subType.equalsIgnoreCase(range.subType))) &&
       (range.charset == Wildcard || charset.forall(_.equalsIgnoreCase(range.charset))) &&
-      (otherParameters.isEmpty || {
-        // `otherParameters` needs to be fully contained within `range.otherParameters` (ignoring case)
+      (range.mainType == Wildcard || range.subType == Wildcard || otherParameters.isEmpty || {
+        // `otherParameters` needs to be fully contained within `range.otherParameters` (ignoring case), but only if the main/sub type aren't wildcards
         val rangeOtherParametersLowerCased = range.otherParameters.map(x => (x._1.toLowerCase, x._2.toLowerCase))
         otherParametersLowerCased.forall { case (k, v) =>
           rangeOtherParametersLowerCased.get(k).contains(v)

--- a/core/src/test/scala/sttp/model/MediaTypeTests.scala
+++ b/core/src/test/scala/sttp/model/MediaTypeTests.scala
@@ -67,16 +67,50 @@ class MediaTypeTests extends AnyFlatSpec with Matchers with TableDrivenPropertyC
     (MediaType.ApplicationJson, ContentTypeRange("application", "*", "*", EmptyParameters), true),
     (MediaType.ApplicationJson, ContentTypeRange("application", "json", "*", EmptyParameters), true),
     (MediaType.ApplicationJson, ContentTypeRange("application", "json", "*", Map("a" -> "1")), true),
-    (MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "truE")), ContentTypeRange("application", "json", "*", Map("A" -> "TrUe")), true),
-    (MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1")), ContentTypeRange("application", "json", "*", Map("A" -> "1", "b" -> "2")), true),
-    (MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1", "b" -> "2")), ContentTypeRange("application", "json", "*", Map("A" -> "1")), false),
-    (MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1")), ContentTypeRange("application", "json", "*", Map("b" -> "2")), false),
+    (
+      MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "truE")),
+      ContentTypeRange("application", "json", "*", Map("A" -> "TrUe")),
+      true
+    ),
+    (
+      MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1")),
+      ContentTypeRange("application", "json", "*", Map("A" -> "1", "b" -> "2")),
+      true
+    ),
+    (
+      MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1", "b" -> "2")),
+      ContentTypeRange("application", "json", "*", Map("A" -> "1")),
+      false
+    ),
+    (
+      MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1")),
+      ContentTypeRange("application", "json", "*", Map("b" -> "2")),
+      false
+    ),
+    (
+      MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1")),
+      AnyRange,
+      true
+    ),
+    (
+      MediaType.ApplicationJson.copy(otherParameters = Map("a" -> "1")),
+      ContentTypeRange("application", "*", "*", EmptyParameters),
+      true
+    ),
     //
     (MediaType.ApplicationJson.charset("utf-8"), ContentTypeRange("*", "*", "utf-16", EmptyParameters), false),
     (MediaType("*", "html").charset("utf-8"), ContentTypeRange("*", "json", "utf-16", EmptyParameters), false),
     (MediaType("text", "*").charset("utf-8"), ContentTypeRange("text", "*", "utf-16", EmptyParameters), false),
-    (MediaType.ApplicationJson.charset("utf-8"), ContentTypeRange("application", "*", "utf-16", EmptyParameters), false),
-    (MediaType.ApplicationJson.charset("utf-8"), ContentTypeRange("application", "json", "utf-16", EmptyParameters), false),
+    (
+      MediaType.ApplicationJson.charset("utf-8"),
+      ContentTypeRange("application", "*", "utf-16", EmptyParameters),
+      false
+    ),
+    (
+      MediaType.ApplicationJson.charset("utf-8"),
+      ContentTypeRange("application", "json", "utf-16", EmptyParameters),
+      false
+    ),
     //
     (MediaType.ApplicationJson.charset("utf-8"), ContentTypeRange("application", "json", "*", EmptyParameters), true),
     (MediaType.ApplicationOctetStream, ContentTypeRange("*", "*", "utf-8", EmptyParameters), true)
@@ -91,8 +125,14 @@ class MediaTypeTests extends AnyFlatSpec with Matchers with TableDrivenPropertyC
   private val bestMatchCases = Table(
     ("ranges", "best match"),
     (Seq(AnyRange), Some(MediaType.ApplicationJson.charset("utf-8"))),
-    (Seq(ContentTypeRange("application", "json", "*", EmptyParameters)), Some(MediaType.ApplicationJson.charset("utf-8"))),
-    (Seq(ContentTypeRange("application", "xml", "*", EmptyParameters)), Some(MediaType.ApplicationXml.charset("utf-8"))),
+    (
+      Seq(ContentTypeRange("application", "json", "*", EmptyParameters)),
+      Some(MediaType.ApplicationJson.charset("utf-8"))
+    ),
+    (
+      Seq(ContentTypeRange("application", "xml", "*", EmptyParameters)),
+      Some(MediaType.ApplicationXml.charset("utf-8"))
+    ),
     (
       Seq(
         ContentTypeRange("application", "xml", "*", EmptyParameters),
@@ -116,7 +156,10 @@ class MediaTypeTests extends AnyFlatSpec with Matchers with TableDrivenPropertyC
       Some(MediaType.ApplicationXml.charset("utf-8"))
     ),
     (
-      Seq(ContentTypeRange("text", "*", "*", EmptyParameters), ContentTypeRange("application", "*", "*", EmptyParameters)),
+      Seq(
+        ContentTypeRange("text", "*", "*", EmptyParameters),
+        ContentTypeRange("application", "*", "*", EmptyParameters)
+      ),
       Some(MediaType.TextHtml.charset("utf-8"))
     ),
     (
@@ -124,7 +167,10 @@ class MediaTypeTests extends AnyFlatSpec with Matchers with TableDrivenPropertyC
       Some(MediaType.TextHtml.charset("iso-8859-1"))
     ),
     (
-      Seq(ContentTypeRange("text", "html", "iso-8859-1", EmptyParameters), ContentTypeRange("text", "html", "utf-8", EmptyParameters)),
+      Seq(
+        ContentTypeRange("text", "html", "iso-8859-1", EmptyParameters),
+        ContentTypeRange("text", "html", "utf-8", EmptyParameters)
+      ),
       Some(MediaType.TextHtml.charset("iso-8859-1"))
     ),
     (


### PR DESCRIPTION
Follow-up to #306

cc @kamilkloch - when the range is `*/*` or `sth/*`, we don't require parameters to match. Otherwise there are problems with boundaries in multiparts (and probably others)