### PR TITLE
optimize uri parsing to reduce StringBuilder allocations

### DIFF
--- a/core/src/main/scala/sttp/model/UriInterpolator.scala
+++ b/core/src/main/scala/sttp/model/UriInterpolator.scala
@@ -731,6 +731,16 @@ object UriInterpolator {
             case Singleton(ExpressionToken(s: Array[_])) =>
               b ++= s.flatMap(anyToStringOpt)
               doToSeq(tailTs)
+            case valueTs if(valueTs.size == 1) =>
+              // This case is equivalent to the next one but optimizes for the 
+              // frequent scenario where the sequence contains a single element.
+              valueTs.get(0) match {
+                case StringToken(s)     => b += decode(s, decodePlusAsSpace)
+                case ExpressionToken(e) => anyToStringOpt(e).foreach(b += _)
+                case EqInQuery          => b += "="
+                case _                  => 
+              }
+              doToSeq(tailTs)
             case valueTs =>
               val mbStr = valueTs mkStringOpt {
                 case StringToken(s)     => Some(decode(s, decodePlusAsSpace))


### PR DESCRIPTION
## Problem

The uri parsing has a high allocation rate of `StringBuilder` objects in `ArrayView.mkStringOpt`. The parsing happens on each incoming request and the implementation of `mkStringOpt` uses a large `StringBuilder` initialized with 128 chars. The actual strings are typically much smaller representing a single path element.

## Solution

I've debugged the code and noticed that the vast majority of calls have a `valueTs` with a single path element. I've added a special case for it so `mkStringOpt` can be avoided.

## Notes 

- This is part of https://github.com/softwaremill/tapir/issues/3552.
- It's probably better to avoid the custom initial `StringBuilder` capacity in `mkStringOpt` since the strings seem generally small and growing the buffer is typically not too expensive. I can follow up on that if you like.
- Another alternative is optimizing the code that uses `mkStringOpt`.