### PR TITLE
cache `MediaType.toString`

### DIFF
--- a/core/src/main/scala/sttp/model/MediaType.scala
+++ b/core/src/main/scala/sttp/model/MediaType.scala
@@ -63,7 +63,7 @@ case class MediaType(
 
   def isModel: Boolean = mainType.equalsIgnoreCase("model")
 
-  override def toString: String = {
+  override lazy val toString: String = {
     val sb = new java.lang.StringBuilder(32) // "application/json; charset=utf-8".length == 31 ;)
     sb.append(mainType).append('/').append(subType)
     charset match {


### PR DESCRIPTION
## Problem

On each request, Tapir uses the `toString` in `MediaType` to produce the header. In my [benchmark](https://github.com/fwbrasil/rinha-2024-q1), the instance of `MediaType` is always the same but the string has to be produced again on each request.

##  Solution

Make `toString` a lazy val so the value can be reused.

## Notes

- Are `MediaType` meant to be singletons? If yes, we could make `toString` a `val` to avoid the lazy val volatile read. It's likely a quite small overhead, though.