### PR TITLE
fix breaking change in MediaType.toString

### DIFF
--- a/core/src/main/scala/sttp/model/MediaType.scala
+++ b/core/src/main/scala/sttp/model/MediaType.scala
@@ -63,7 +63,9 @@ case class MediaType(
 
   def isModel: Boolean = mainType.equalsIgnoreCase("model")
 
-  override lazy val toString: String = {
+  // Cache 'toString' given that it's called in the hot path 
+  // of request processing to generate headers.
+  private lazy val toStringCache: String = {
     val sb = new java.lang.StringBuilder(32) // "application/json; charset=utf-8".length == 31 ;)
     sb.append(mainType).append('/').append(subType)
     charset match {
@@ -77,6 +79,7 @@ case class MediaType(
     sb.toString
   }
 
+  override def toString() = toStringCache
   override lazy val hashCode: Int = toString.toLowerCase.hashCode
 
   override def equals(that: Any): Boolean =

--- a/core/src/test/scala/sttp/model/MediaTypeTests.scala
+++ b/core/src/test/scala/sttp/model/MediaTypeTests.scala
@@ -59,6 +59,12 @@ class MediaTypeTests extends AnyFlatSpec with Matchers with TableDrivenPropertyC
     an[IllegalArgumentException] shouldBe thrownBy(MediaType.unsafeApply("te=xt", "plain"))
   }
 
+  it should "have a regular toString" in {
+    val mt = MediaType.ApplicationGzip
+    mt.toString shouldBe "application/gzip"
+    mt.toString() shouldBe "application/gzip"
+  }
+
   private val matchCases = Table(
     ("media type", "content type range", "matches"),
     // simple matching


### PR DESCRIPTION
## Problem

https://github.com/softwaremill/sttp-model/pull/331 changed `MediaType.toString` to become a `lazy val`, which is a breaking change. I'm seeing this issue while trying to publish a version of Tapir with the optimizations mentioned in https://github.com/softwaremill/tapir/issues/3552.

## Solution

Make the `lazy val` private and keep the same `toString()` interface as before.