### PR TITLE
Fix Rfc850DatetimeFormat to handle 2-digit year

### DIFF
--- a/core/src/main/scala/sttp/model/Header.scala
+++ b/core/src/main/scala/sttp/model/Header.scala
@@ -19,6 +19,8 @@ import sttp.model.internal.Validate._
 
 import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 import java.util.Locale
 import scala.util.{Failure, Success, Try}
 import scala.util.hashing.MurmurHash3
@@ -141,8 +143,12 @@ object Header {
 
   //
 
-  private lazy val Rfc850DatetimePattern = "dd-MMM-yyyy HH:mm:ss zzz"
-  private lazy val Rfc850DatetimeFormat = DateTimeFormatter.ofPattern(Rfc850DatetimePattern, Locale.US)
+  private lazy val Rfc850DatetimeFormat =
+    DateTimeFormatterBuilder()
+      .appendPattern("dd-MMM-")
+      .appendValueReduced(ChronoField.YEAR, 2, 4, 1970)
+      .appendPattern(" HH:mm:ss zzz")
+      .toFormatter(Locale.US);
 
   val Rfc850WeekDays = Set("mon", "tue", "wed", "thu", "fri", "sat", "sun") // not private b/c of bin-compat
   private val Rfc1123WeekDays: Array[String] = Array("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")

--- a/core/src/main/scala/sttp/model/Header.scala
+++ b/core/src/main/scala/sttp/model/Header.scala
@@ -144,7 +144,7 @@ object Header {
   //
 
   private lazy val Rfc850DatetimeFormat =
-    DateTimeFormatterBuilder()
+    new DateTimeFormatterBuilder()
       .appendPattern("dd-MMM-")
       .appendValueReduced(ChronoField.YEAR, 2, 4, 1970)
       .appendPattern(" HH:mm:ss zzz")

--- a/core/src/test/scalajvm/sttp/model/HeaderTests.scala
+++ b/core/src/test/scalajvm/sttp/model/HeaderTests.scala
@@ -59,4 +59,28 @@ class HeaderTests extends AnyFlatSpec with Matchers {
   "rfc1123-date1" should "be parsed correctly" in {
     Header.parseHttpDate(rfc1123DatetimeFormatted) shouldBe Right(rfc1123DatetimeToBeChecked)
   }
+
+  "rfc850-2-digit-year-after-70" should "be parsed as 19xx" in {
+    Header.parseHttpDate("Sun, 08-Feb-70 02:03:04 GMT") shouldBe Right(
+      Instant.from {
+        ZonedDateTime.of(LocalDateTime.of(1970, 2, 8, 2, 3, 4), ZoneId.of("Z"))
+      }
+    )
+  }
+
+  "rfc850-2-digit-year-before-69" should "be parsed as 20xx" in {
+    Header.parseHttpDate("Fri, 08-Feb-69 02:03:04 GMT") shouldBe Right(
+      Instant.from {
+        ZonedDateTime.of(LocalDateTime.of(2069, 2, 8, 2, 3, 4), ZoneId.of("Z"))
+      }
+    )
+  }
+
+  "rfc850-4-digit-year" should "be parsed correctly" in {
+    Header.parseHttpDate("Wed, 08-Feb-2023 02:03:04 GMT") shouldBe Right(
+      Instant.from {
+        ZonedDateTime.of(LocalDateTime.of(2023, 2, 8, 2, 3, 4), ZoneId.of("Z"))
+      }
+    )
+  }
 }


### PR DESCRIPTION
Per https://github.com/akka/akka/issues/17714#issuecomment-112004002, 2-digit year is a valid representation and should be adjusted into the period 1970-2069.