### PR TITLE
Add support for filename* on disposition header getter

### DIFF
--- a/core/src/main/scala/sttp/model/Part.scala
+++ b/core/src/main/scala/sttp/model/Part.scala
@@ -14,7 +14,12 @@ case class Part[+T](
   def dispositionParam(k: String, v: String): Part[T] = copy(otherDispositionParams = otherDispositionParams + (k -> v))
 
   def fileName(v: String): Part[T] = dispositionParam(FileNameDispositionParam, v)
-  def fileName: Option[String] = otherDispositionParams.get(FileNameDispositionParam)
+
+  // Return filename encoded in non ISO-8859-1 if available
+  // See: https://httpwg.org/specs/rfc6266.html#disposition.parameter.filename
+  def fileName: Option[String] = otherDispositionParams
+    .get(NonAsciiFileNameDispositionParam)
+    .orElse(otherDispositionParams.get(FileNameDispositionParam))
 
   def contentType(v: MediaType): Part[T] = header(Header.contentType(v), replaceExisting = true)
   def contentType(v: String): Part[T] = header(Header(HeaderNames.ContentType, v), replaceExisting = true)
@@ -89,4 +94,5 @@ object Part {
 
   val NameDispositionParam = "name"
   val FileNameDispositionParam = "filename"
+  val NonAsciiFileNameDispositionParam = "filename*"
 }

--- a/core/src/test/scala/sttp/model/PartTest.scala
+++ b/core/src/test/scala/sttp/model/PartTest.scala
@@ -14,6 +14,19 @@ class PartTest extends AnyFlatSpec with Matchers {
     part.contentDispositionHeaderValue shouldBe """form-data; name="name"; filename="fó1.txt""""
   }
 
+  it should "retain non-ascii characters in filename*" in {
+    val expectedFileName = "fó1.txt"
+    val part = Part("name", 42, otherDispositionParams = Map("filename*" -> expectedFileName)).fileName("f1.txt")
+    part.contentDispositionHeaderValue shouldBe s"""form-data; name="name"; filename*="$expectedFileName"; filename="f1.txt""""
+    part.fileName shouldBe Some(expectedFileName)
+  }
+
+  it should "fallback to basic filename if filename* is not present" in {
+    val part = Part("name", 42).fileName("f1.txt")
+    part.contentDispositionHeaderValue shouldBe s"""form-data; name="name"; filename="f1.txt""""
+    part.fileName shouldBe Some("f1.txt")
+  }
+
   it should "escape double quote and backslash in filename" in {
     val part = Part("name", 42).fileName("f\"\\1.txt")
     part.contentDispositionHeaderValue shouldBe """form-data; name="name"; filename="f\"\\1.txt""""


### PR DESCRIPTION
We came across an issue where when creating a multipart, if the name contains non ascii characters, they get added as `filename*` in the disposition header.

This PR is to address the issue, so we can retrieve the non-ascii file name correctly.