### PR TITLE
Improve range & content range parsing

### DIFF
--- a/core/src/main/scala/sttp/model/Headers.scala
+++ b/core/src/main/scala/sttp/model/Headers.scala
@@ -19,6 +19,8 @@ trait HasHeaders {
   def headers(h: String): Seq[String] = headers.filter(_.is(h)).map(_.value)
 
   def contentType: Option[String] = header(HeaderNames.ContentType)
+
+  /** The content length parsed into a long, if present. If the content length is not a number, `None` is returned. */
   def contentLength: Option[Long] = header(HeaderNames.ContentLength).flatMap(ParseUtils.toLongOption)
 
   def cookies: Seq[Either[String, CookieWithMeta]] = headers(HeaderNames.SetCookie).map(h => CookieWithMeta.parse(h))

--- a/core/src/main/scala/sttp/model/headers/Host.scala
+++ b/core/src/main/scala/sttp/model/headers/Host.scala
@@ -8,6 +8,8 @@ object Host {
     * `]` characters are removed. If the port is not a number, it is discarded.
     *
     * For example, `example.com:8080` will be parsed into `("example.com", Some(8080))`.
+    *
+    * If the port is not a number, it is discarded.
     */
   def parseHostAndPort(v: String): (String, Option[Int]) = {
     val lastColonIndex = v.lastIndexOf(":")

--- a/core/src/test/scala/sttp/model/headers/ContentRangeTest.scala
+++ b/core/src/test/scala/sttp/model/headers/ContentRangeTest.scala
@@ -6,7 +6,7 @@ import sttp.model.ContentRangeUnits
 
 class ContentRangeTest extends AnyFlatSpec with Matchers {
 
-  it should "properly pars simplest ContentRange header" in {
+  it should "properly parse simplest ContentRange header" in {
     val actual = ContentRange.parse("bytes 200-1000/1200")
     actual shouldBe Right(ContentRange(ContentRangeUnits.Bytes, Some((200, 1000)), Some(1200)))
   }
@@ -29,6 +29,22 @@ class ContentRangeTest extends AnyFlatSpec with Matchers {
 
   it should "fail parsing ContentRange without range and size" in {
     ContentRange.parse("bytes */*") shouldBe Left("Invalid Content-Range")
+  }
+
+  it should "fail parsing ContentRange with invalid range end" in {
+    ContentRange.parse("bytes 200-abc/*") shouldBe Left("Invalid end of range: abc")
+  }
+
+  it should "fail parsing ContentRange with invalid range start" in {
+    ContentRange.parse("bytes abc-200/*") shouldBe Left("Invalid start of range: abc")
+  }
+
+  it should "fail parsing ContentRange with missing range start" in {
+    ContentRange.parse("bytes -200/*") shouldBe Left("Invalid start of range: ")
+  }
+
+  it should "fail parsing ContentRange with missing range end" in {
+    ContentRange.parse("bytes 200-/*") shouldBe Left("Invalid range: 200-")
   }
 
   it should "fail parsing ContentRange with incorrect range" in {

--- a/core/src/test/scala/sttp/model/headers/RangeTest.scala
+++ b/core/src/test/scala/sttp/model/headers/RangeTest.scala
@@ -77,6 +77,14 @@ class RangeTest extends AnyFlatSpec with Matchers {
     Range.parse("bytes=700-500") shouldBe Left("Invalid Range")
   }
 
+  it should "fail parsing header when the range start is not a number" in {
+    Range.parse("bytes=abc-500") shouldBe Left("Invalid start of range: abc")
+  }
+
+  it should "fail parsing header when the range end is not a number" in {
+    Range.parse("bytes=500-abc") shouldBe Left("Invalid end of range: abc")
+  }
+
   it should "fail parsing header without correct range" in {
     Range.parse("bytes=-") shouldBe Left("Invalid Range")
   }


### PR DESCRIPTION
Also, comment that `Host.parseHostAndPort` drops the port silently in case of parsing errors.